### PR TITLE
CPU_ONLY easy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# .gitignore
+
+*~
+build/
+nets/models/
+nets/tracker_output/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,24 +8,34 @@ endif()
 
 find_package(Boost COMPONENTS system filesystem regex REQUIRED)
 
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 find_package(TinyXML REQUIRED)
+
 
 find_package( OpenCV REQUIRED )
 message("Open CV version is ${OpenCV_VERSION}")
 
 find_package(CUDA REQUIRED)
-include_directories(${CUDA_INCLUDE_DIRS})
 # Note: If can't find CUDA, please uncomment the below line and set the path manually
 # set(CUDA_INCLUDE_DIRS /path_to_cuda/include)
+include_directories(${CUDA_INCLUDE_DIRS})
+message("CUDA_INCLUDE_DIRS is ${CUDA_INCLUDE_DIRS}")
+
 
 find_package(Caffe REQUIRED)
-include_directories(${Caffe_INCLUDE_DIRS})
-add_definitions(${Caffe_DEFINITIONS})    # ex. -DCPU_ONLY
-message("Caffe_DIR is ${Caffe_DIR}")	#specify Caffe_DIR in /cmake/Modules/FindCaffe.cmake
-# Note: If can't find Caffe, please uncomment the below line and set the path manually
+# If Caffe not found, configure line 5 of cmake/Modules/FindCaffe.cmake
+# If that fails uncomment the two lines below and set paths manually
 # set(Caffe_DIR /path_to_caffe/build/install)
 # set(Caffe_INCLUDE_DIRS /path_to_caffe/build/install/include)
+include_directories(${Caffe_INCLUDE_DIRS})
+# Uncomment for CPU only:
+# set(Caffe_DEFINITIONS -DCPU_ONLY)
+add_definitions(${Caffe_DEFINITIONS})
+message("Caffe_DEFINITIONS is ${Caffe_DEFINITIONS}")
+message("Caffe_DIR is ${Caffe_DIR}")
+message("Caffe_INCLUDE_DIRS is ${Caffe_INCLUDE_DIRS}")
+
 
 set(GLOG_LIB glog)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ sudo apt-get install libopencv-dev
 sudo apt-get install libtinyxml-dev 
 ```
 
+* CPU_ONLY mode (optional and not recommended)
+
+GPUs are strongly suggested as the code runs ~30X slower in CPU_ONLY mode. It is listed as an option only if your system doesn’t have GPU support. To configure this, uncomment the `CPU_ONLY` line in `CMakeLists.txt` as shown below:
+```
+# Uncomment for CPU only:
+set(Caffe_DEFINITIONS -DCPU_ONLY)
+```
+
 ### Compile
 
 From the main directory, type:

--- a/cmake/Modules/FindCaffe.cmake
+++ b/cmake/Modules/FindCaffe.cmake
@@ -1,9 +1,8 @@
 # Caffe package
 unset(Caffe_FOUND)
 
-###Set the variable Caffe_DIR as the root of your caffe directory
-#set(Caffe_DIR /*Specify path to caffe here*/)
-
+### Set the variable Caffe_DIR as the root of your caffe directory
+# set(Caffe_DIR /path_to_caffe/build/install)
 
 find_path(Caffe_INCLUDE_DIRS NAMES caffe/caffe.hpp caffe/common.hpp caffe/net.hpp caffe/proto/caffe.pb.h caffe/util/io.hpp caffe/vision_layers.hpp
   HINTS
@@ -15,7 +14,8 @@ find_library(Caffe_LIBRARIES NAMES caffe
   HINTS
   ${Caffe_DIR}/build/lib)
 
-message("lib_dirs:${Caffe_LIBRARIES}")
+message("Caffe_LIBRARIES HINTS is ${Caffe_DIR}/build/lib")
+message("Caffe_LIBRARIES is ${Caffe_LIBRARIES}")
 
 if(Caffe_LIBRARIES AND Caffe_INCLUDE_DIRS)
     set(Caffe_FOUND 1)

--- a/src/tracker/tracker_manager.cpp
+++ b/src/tracker/tracker_manager.cpp
@@ -38,8 +38,14 @@ void TrackerManager::TrackAll(const size_t start_video_num, const int pause_val)
     tracker_->Init(image_curr, bbox_gt, regressor_);
 
     // Iterate over the remaining frames of the video.
-    for (size_t frame_num = first_frame + 1; frame_num < video.all_frames.size(); ++frame_num) {
-
+    printf("Frames: ");
+    size_t frame_num = first_frame + 1;
+    for (; frame_num < video.all_frames.size(); ++frame_num) {
+      if (frame_num % 100 == 0) {
+          // force flush as printf without newline will buffer
+          printf("%lu, ", frame_num);
+          fflush(stdout);
+      }
       // Get image for the current frame.
       // (The ground-truth bounding box is used only for visualization).
       const bool draw_bounding_box = false;
@@ -63,6 +69,8 @@ void TrackerManager::TrackAll(const size_t start_video_num, const int pause_val)
       ProcessTrackOutput(frame_num, image_curr, has_annotation, bbox_gt,
                            bbox_estimate_uncentered, pause_val);
     }
+    printf("%lu\n", frame_num);
+
     PostProcessVideo();
   }
   PostProcessAll();


### PR DESCRIPTION
CPU_ONLY Mode:
- CPU_ONLY line that can be uncommented for easy configuration
- Move CMake set() commands so uncomment doesn’t leave them as a no-op
- CMake debug output to better track down caffe build dependencies
- Update every 100 frames as otherwise CPU_ONLY mode is so slow as to
possibly appear broken
- README instructions
- Fixes #39

CPU_ONLY speed test:
- Command: bash scripts/save_videos_test.sh tmp/vot2014
- System: AWS p2.xlarge instance with Nvidia Tesla K80
- Results:
  GPU: 2.28 minutes
  CPU: 1.22 hours (32X slower)

Other:
- .gitignore for build/, nets/models/ and nets/tracker_output/