### PR TITLE
NO_DISPLAY for headless server (e.g. AWS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ find_package(TinyXML REQUIRED)
 
 find_package( OpenCV REQUIRED )
 message("Open CV version is ${OpenCV_VERSION}")
+# Uncomment for no display (e.g. AWS instance)
+# set(Opencv_DEFINITIONS -DNO_DISPLAY)
+add_definitions(${Opencv_DEFINITIONS})
+message("Opencv_DEFINITIONS is ${Opencv_DEFINITIONS}")
 
 find_package(CUDA REQUIRED)
 include_directories(${CUDA_INCLUDE_DIRS})

--- a/src/loader/loader_imagenet_det.cpp
+++ b/src/loader/loader_imagenet_det.cpp
@@ -164,10 +164,12 @@ void LoaderImagenetDet::ShowImages() const {
     cv::Mat image;
     LoadImage(image_index, &image);
 
+#ifndef NO_DISPLAY
     // Display the image and wait for a keystroke to continue.
     cv::namedWindow( "Display window", cv::WINDOW_AUTOSIZE );// Create a window for display.
     cv::imshow( "Display window", image );                   // Show our image inside it.
     cv::waitKey(0);                                          // Wait for a keystroke in the window
+#endif
   }
 }
 
@@ -271,10 +273,12 @@ void LoaderImagenetDet::ShowAnnotations() const {
       // Draw the annotation on the image.
       bbox.DrawBoundingBox(&image);
 
+#ifndef NO_DISPLAY
       // Display the image with the annotation.
       cv::namedWindow( "Display window", cv::WINDOW_AUTOSIZE );// Create a window for display.
       cv::imshow( "Display window", image );                   // Show our image inside it.
       cv::waitKey(0);                                          // Wait for a keystroke in the window
+#endif
     }
   }
 }
@@ -360,9 +364,11 @@ void LoaderImagenetDet::ShowAnnotationsRand() const {
     cv::Mat image_copy;
     image.copyTo(image_copy);
     bbox.DrawBoundingBox(&image_copy);
+#ifndef NO_DISPLAY
     cv::namedWindow( "Display window", cv::WINDOW_AUTOSIZE );// Create a window for display.
     cv::imshow( "Display window", image_copy );                   // Show our image inside it.
     cv::waitKey(0);                                          // Wait for a keystroke in the window
+#endif
   }
 }
 
@@ -389,8 +395,10 @@ void LoaderImagenetDet::ShowAnnotationsShift() const {
       cv::Mat image_copy;
       image.copyTo(image_copy);
       bbox.Draw(0, 255, 0, &image_copy);
+#ifndef NO_DISPLAY
       cv::namedWindow( "Display window", cv::WINDOW_AUTOSIZE );// Create a window for display.
       cv::imshow( "Display window", image_copy );                   // Show our image inside it.
+#endif
 
       // If desired, save this image with its annotation.
       if (save_images) {

--- a/src/loader/video.cpp
+++ b/src/loader/video.cpp
@@ -45,9 +45,11 @@ void Video::ShowVideo() const {
     if(!image.data ) {
       printf("Could not open or find image %s\n", image_file.c_str());
     } else {
+#ifndef NO_DISPLAY
       cv::namedWindow( "Display window", cv::WINDOW_AUTOSIZE );// Create a window for display.
       cv::imshow( "Display window", image );                   // Show our image inside it.
       cv::waitKey(1);                                          // Wait for a keystroke in the window
+#endif
     }
   } // For all frames in video
 }

--- a/src/loader/video_loader.cpp
+++ b/src/loader/video_loader.cpp
@@ -26,11 +26,13 @@ void VideoLoader::ShowVideos() const {
     const Video& video = videos_[i];
     printf("Showing video %zu: %s\n", i, video.path.c_str());
 
+#ifndef NO_DISPLAY
     // Show the video with the annotations.
     video.ShowVideo();
 
     // Wait for a keystroke.
     cv::waitKey(0);
+#endif
   } // For each video
 }
 
@@ -72,9 +74,11 @@ void VideoLoader::ShowVideosShift() const {
         raw_image.copyTo(full_image_with_bbox);
         bbox.DrawBoundingBox(&full_image_with_bbox);
 
+#ifndef NO_DISPLAY
         cv::namedWindow("Raw image", cv::WINDOW_AUTOSIZE);// Create a window for display.
         cv::imshow("Raw image", full_image_with_bbox);                   // Show our image inside it.
-
+#endif
+          
         example_generator.Reset(bbox_prev, bbox, image_prev, raw_image);
         example_generator.set_indices(video_index, frame_index);
 

--- a/src/tracker/tracker.cpp
+++ b/src/tracker/tracker.cpp
@@ -84,8 +84,10 @@ void Tracker::ShowTracking(const cv::Mat& target_pad, const cv::Mat& curr_search
   cv::resize(target_pad, target_resize, cv::Size(227, 227));
 
   // Show the resized target.
+#ifndef NO_DISPLAY
   cv::namedWindow("Target", cv::WINDOW_AUTOSIZE );// Create a window for display.
   cv::imshow("Target", target_resize );                   // Show our image inside it.
+#endif
 
   // Resize the image.
   cv::Mat image_resize;
@@ -100,7 +102,9 @@ void Tracker::ShowTracking(const cv::Mat& target_pad, const cv::Mat& curr_search
   image_resize.copyTo(image_with_box);
   bbox_estimate_unscaled.DrawBoundingBox(&image_with_box);
 
+#ifndef NO_DISPLAY
   cv::namedWindow("Estimate", cv::WINDOW_AUTOSIZE );// Create a window for display.
   cv::imshow("Estimate", image_with_box );                   // Show our image inside it.
   cv::waitKey(0);
+#endif
 }

--- a/src/tracker/tracker_manager.cpp
+++ b/src/tracker/tracker_manager.cpp
@@ -90,12 +90,14 @@ void TrackerVisualizer::ProcessTrackOutput(
   // Draw estimated bounding box of the target location (red).
   bbox_estimate_uncentered.Draw(255, 0, 0, &full_output);
 
+#ifndef NO_DISPLAY
   // Show the image with the estimated and ground-truth bounding boxes.
   cv::namedWindow("Full output", cv::WINDOW_AUTOSIZE ); // Create a window for display.
   cv::imshow("Full output", full_output );                   // Show our image inside it.
 
   // Pause for pause_val milliseconds, or until user input (if pause_val == 0).
   cv::waitKey(pause_val);
+#endif
 }
 
 void TrackerVisualizer::VideoInit(const Video& video, const size_t video_num) {

--- a/src/train/example_generator.cpp
+++ b/src/train/example_generator.cpp
@@ -162,8 +162,10 @@ void ExampleGenerator::VisualizeExample(const cv::Mat& target_pad,
   // Show resized target.
   cv::Mat target_resize;
   cv::resize(target_pad, target_resize, cv::Size(227,227));
+#ifndef NO_DISPLAY
   cv::namedWindow("Target object", cv::WINDOW_AUTOSIZE );// Create a window for display.
   cv::imshow("Target object", target_resize);                   // Show our image inside it.
+#endif
   if (save_images) {
     const string target_name = "Image" + num2str(video_index_) + "_" + num2str(frame_index_) + "target.jpg";
     cv::imwrite(target_name, target_resize);
@@ -179,12 +181,14 @@ void ExampleGenerator::VisualizeExample(const cv::Mat& target_pad,
   bbox_gt_unscaled.Draw(0, 255, 0, &image_resize);
 
   // Show image with bbox.
+#ifndef NO_DISPLAY
   cv::namedWindow("Search_region+gt", cv::WINDOW_AUTOSIZE );// Create a window for display.
   cv::imshow("Search_region+gt", image_resize );                   // Show our image inside it.
+  cv::waitKey(0);
+#endif
+
   if (save_images) {
     const string image_name = "Image" + num2str(video_index_) + "_" + num2str(frame_index_) + "image.jpg";
     cv::imwrite(image_name, image_resize);
   }
-
-  cv::waitKey(0);
 }


### PR DESCRIPTION
GOTURN can’t run on an a cloud instance (e.g. AWS) as it has no
display. Instead it exits with the following:

`Gtk-WARNING **: cannot open display:`

I would prefer to make this a runtime test to automatically disable for
headless servers. Not knowing how to do that, I’ve done the following
as a build configuration:
- Wrap cv::namedwindow, imshow and waitKey with #ifndef NO_DISPLAY
- Change ordering in example_generator.cpp so that waitKey happens
before image save (avoids multiple #ifndef lines)
- Nothing added to README as this is a special use case