### PR TITLE
Update download_trained_model.sh

### DIFF
--- a/scripts/download_trained_model.sh
+++ b/scripts/download_trained_model.sh
@@ -2,5 +2,5 @@
 
 mkdir -p nets/models/pretrained_model 
 cd nets/models/pretrained_model
-wget http://cs.stanford.edu/people/davheld/public/GOTURN/trained_model/tracker.caffemodel
+wget http://cs.stanford.edu/people/davheld/public/GOTURN/trained_model/tracker.caffemodel --no-check-certificate
 cd ../../../


### PR DESCRIPTION
cs.stanford.edu certificate is not verifiable

```
ubuntu@ip-172-31-44-5:~/GOTURN$ bash scripts/download_trained_model.sh --no-check-certificate
--2018-09-06 15:40:12--  http://cs.stanford.edu/people/davheld/public/GOTURN/trained_model/tracker.caffemodel
Resolving cs.stanford.edu (cs.stanford.edu)... 171.64.64.64
Connecting to cs.stanford.edu (cs.stanford.edu)|171.64.64.64|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://cs.stanford.edu/people/davheld/public/GOTURN/trained_model/tracker.caffemodel [following]
--2018-09-06 15:40:12--  https://cs.stanford.edu/people/davheld/public/GOTURN/trained_model/tracker.caffemodel
Connecting to cs.stanford.edu (cs.stanford.edu)|171.64.64.64|:443... connected.
ERROR: cannot verify cs.stanford.edu's certificate, issued by ‘CN=InCommon RSA Server CA,OU=InCommon,O=Internet2,L=Ann Arbor,ST=MI,C=US’:
  Unable to locally verify the issuer's authority.
To connect to cs.stanford.edu insecurely, use `--no-check-certificate'.
```